### PR TITLE
Fix missing day in March

### DIFF
--- a/CalendarView/CalendarView/Classes/MonthView.swift
+++ b/CalendarView/CalendarView/Classes/MonthView.swift
@@ -87,12 +87,12 @@ class MonthView: UIView {
   func setWeeks() {
     if weeks.count > 0 {
       let numWeeks = Int(numDays / 7)
-      var currentDay = date.startOf(.Months).endOf(.Days).subtract(startsOn - 1, .Days)
+      let firstVisibleDate  = date.startOf(.Months).endOf(.Days).subtract(startsOn - 1, .Days).startOf(.Days)
       for i in 1...weeks.count {
+        let firstDateOfWeek = firstVisibleDate.add(7*(i-1), .Days)
         let week = weeks[i - 1]
         week.month = date
-        week.date = currentDay
-        currentDay = currentDay.endOf(.Days).add(7, .Days)
+        week.date = firstDateOfWeek
         week.hidden = i > numWeeks
       }
     }

--- a/CalendarView/CalendarViewTests/CalendarViewTests.swift
+++ b/CalendarView/CalendarViewTests/CalendarViewTests.swift
@@ -32,4 +32,13 @@ class CalendarViewTests: XCTestCase {
         XCTAssertEqual(2, date2.day)
     }
 
+    // See: https://github.com/n8armstrong/CalendarView/issues/7
+    func testSecondSundayInMarchBug() {
+        let marchFirst = moment("3-1-2016")!
+        let firstVisibleDay = marchFirst.startOf(.Months).endOf(.Days).subtract(marchFirst.weekday - 1, .Days).startOf(.Days)
+        XCTAssertEqual("February 28, 2016", firstVisibleDay.format("MMMM d, yyyy"))
+        let dayInQuestion = firstVisibleDay.add(14, .Days)
+        XCTAssertEqual(13, dayInQuestion.day)
+    }
+
 }


### PR DESCRIPTION
I now calculate the first day of the weeks based on the first visible day of the month and am careful to start that date at the beginning of the day which seems to fix #7.
